### PR TITLE
Vagrant fixes for baseboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ext/
 packer_cache/*
 .bundle/*
 blobs/*.iso
-packer--virtualbox/
 *.rpm
 *.iso
+builds/*
+.envrc

--- a/centos-7-puppet-jenkins.json
+++ b/centos-7-puppet-jenkins.json
@@ -50,7 +50,7 @@
       "scripts": [
         "scripts/centos/jenkins_prereq.sh",
         "scripts/common/jenkins.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7-puppet4-devtools.json
+++ b/centos-7-puppet4-devtools.json
@@ -64,7 +64,7 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/centos/devtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7-puppet4-rbenv.json
+++ b/centos-7-puppet4-rbenv.json
@@ -79,7 +79,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7-puppet4-ruby.json
+++ b/centos-7-puppet4-ruby.json
@@ -67,7 +67,7 @@
         "scripts/centos/tools.sh",
         "scripts/centos/7/ruby.sh",
         "scripts/centos/7/cleanup-ruby.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7-puppet4.json
+++ b/centos-7-puppet4.json
@@ -62,7 +62,7 @@
         "scripts/centos/7/puppet4.sh",
         "scripts/centos/tools.sh",
         "scripts/centos/7/cleanup-devtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7-vmware.json
+++ b/centos-7-vmware.json
@@ -39,7 +39,7 @@
         "scripts/centos/7/vmware_workstation.sh",
         "scripts/centos/tools.sh",
         "scripts/centos/7/cleanup-devtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7.json
+++ b/centos-7.json
@@ -169,17 +169,17 @@
     "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16",
+    "iso_checksum": "c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb",
     "iso_checksum_type": "sha256",
-    "iso_name": "CentOS-7-x86_64-DVD-1511.iso",
+    "iso_name": "CentOS-7-x86_64-DVD-1611.iso",
     "ks_path": "centos-7/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://mirrors.kernel.org/centos",
-    "mirror_directory": "7.2.1511/isos/x86_64",
+    "mirror_directory": "7.3.1611/isos/x86_64",
     "name": "centos-7",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "centos-7",
-    "version": "2.1.TIMESTAMP"
+    "version": "3.1.TIMESTAMP"
   }
 }
 

--- a/centos-7.json
+++ b/centos-7.json
@@ -156,7 +156,7 @@
         "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"
@@ -182,4 +182,3 @@
     "version": "3.1.TIMESTAMP"
   }
 }
-

--- a/rhel-7-puppet4-ruby.json
+++ b/rhel-7-puppet4-ruby.json
@@ -34,7 +34,7 @@
         "scripts/centos/tools.sh",
         "scripts/centos/7/ruby.sh",
         "scripts/centos/7/cleanup-ruby.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/rhel-7-puppet4.json
+++ b/rhel-7-puppet4.json
@@ -36,7 +36,7 @@
         "scripts/centos/7/puppet4.sh",
         "scripts/centos/tools.sh",
         "scripts/centos/7/cleanup-devtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/rhel-7-rhn-puppet4-ruby.json
+++ b/rhel-7-rhn-puppet4-ruby.json
@@ -66,7 +66,7 @@
         "scripts/centos/tools.sh",
         "scripts/centos/7/ruby.sh",
         "scripts/centos/7/cleanup-ruby.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/rhel-7-rhn-puppet4.json
+++ b/rhel-7-rhn-puppet4.json
@@ -68,7 +68,7 @@
         "scripts/centos/7/puppet4.sh",
         "scripts/centos/tools.sh",
         "scripts/centos/7/cleanup-devtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/rhel-7-rhn.json
+++ b/rhel-7-rhn.json
@@ -75,7 +75,7 @@
       "scripts": [
         "scripts/rhel/7/satellite.sh",
         "scripts/common/vmtools.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/rhel-7.json
+++ b/rhel-7.json
@@ -94,7 +94,7 @@
         "scripts/common/sshd.sh",
         "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
-        "scripts/centos/7/cleanup.sh",
+        "scripts/common/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"
@@ -119,4 +119,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/scripts/common/cleanup.sh
+++ b/scripts/common/cleanup.sh
@@ -1,0 +1,61 @@
+#!/bin/sh -eux
+
+# should output one of 'redhat' 'centos' 'oraclelinux'
+distro="`rpm -qf --queryformat '%{NAME}' /etc/redhat-release | cut -f 1 -d '-'`"
+
+# Remove development and kernel source packages
+yum -y remove gcc cpp kernel-devel kernel-headers;
+
+if [ "$distro" != 'redhat' ]; then
+  yum -y clean all;
+fi
+
+# Clean up network interface persistence
+rm -rf /etc/udev/rules.d/70-persistent-net.rules;
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
+rm -rf /lib/udev/rules.d/75-persistent-net-generator.rules;
+rm -rf /dev/.udev/;
+
+for ndev in `ls -1 /etc/sysconfig/network-scripts/ifcfg-*`; do
+    if [ "`basename $ndev`" != "ifcfg-lo" ]; then
+        sed -i '/^HWADDR/d' "$ndev";
+        sed -i '/^UUID/d' "$ndev";
+    fi
+done
+
+# new-style network device naming for centos7
+if grep -q -i "release 7" /etc/redhat-release ; then
+  # radio off & remove all interface configration
+  nmcli radio all off
+  /bin/systemctl stop NetworkManager.service
+  for ifcfg in `ls /etc/sysconfig/network-scripts/ifcfg-* |grep -v ifcfg-lo` ; do
+    rm -f $ifcfg
+  done
+  rm -rf /var/lib/NetworkManager/*
+
+  echo "==> Setup /etc/rc.d/rc.local for CentOS7"
+  cat <<_EOF_ | cat >> /etc/rc.d/rc.local
+#BENTO-BEGIN
+LANG=C
+# delete all connection
+for con in \`nmcli -t -f uuid con\`; do
+  if [ "\$con" != "" ]; then
+    nmcli con del \$con
+  fi
+done
+# add gateway interface connection.
+gwdev=\`nmcli dev | grep ethernet | egrep -v 'unmanaged' | head -n 1 | awk '{print \$1}'\`
+if [ "\$gwdev" != "" ]; then
+  nmcli c add type eth ifname \$gwdev con-name \$gwdev
+fi
+sed -i "/^#BENTO-BEGIN/,/^#BENTO-END/d" /etc/rc.d/rc.local
+chmod -x /etc/rc.d/rc.local
+#BENTO-END
+_EOF_
+  chmod +x /etc/rc.d/rc.local
+fi
+
+rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;
+
+# delete any logs that have built up during the install
+find /var/log/ -name *.log -type f -exec rm -f {} \;

--- a/scripts/common/vmtools.sh
+++ b/scripts/common/vmtools.sh
@@ -18,6 +18,7 @@ virtualbox-iso|virtualbox-ovf)
     ;;
 
 vmware-iso|vmware-vmx)
+    yum remove -y open-vm-tools
     mkdir -p /tmp/vmfusion;
     mkdir -p /tmp/vmfusion-archive;
     mount -o loop $HOME_DIR/linux.iso /tmp/vmfusion;


### PR DESCRIPTION
* Update to the latest centos 7 because the other version are now in the archive
* fix open-vm-tools vs vendor tools install issue preventing hgfs from working
* fix network interfaces leaving junk behind that causes errors with modern vagrant versions.